### PR TITLE
feat: show duration only for adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ docker network connect pitchboost-net <container>
   "user_id": "<tg_chat_id>",
   "audio_id": "<s3_key>",
   "request_message": "",
-  "scenario": "investor|client|academic",
+  "scenario": "recommendation|evaluation|adaptation",
   "duration_minutes": 1|3|5
 }
 ```
+Поле `duration_minutes` передаётся только для сценария `adaptation`.
 
 Результаты возвращаются в `KAFKA_TOPIC_OUT` тем же `user_id`.
 

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -58,7 +58,7 @@ def create_pitch(
     user_id: int,
     audio_key: str,
     scenario: str,
-    duration_minutes: int,
+    duration_minutes: int | None,
     status: str,
 ) -> models.Pitch:
     pitch = models.Pitch(

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,5 +1,6 @@
 # app/db/models.py
 from datetime import datetime, timezone
+from typing import Optional
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy import Integer, String, ForeignKey, DateTime
 
@@ -28,7 +29,7 @@ class Pitch(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     audio_key: Mapped[str] = mapped_column(String, nullable=False)
     scenario: Mapped[str] = mapped_column(String)
-    duration_minutes: Mapped[int] = mapped_column(Integer)
+    duration_minutes: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )

--- a/app/routers/analyze.py
+++ b/app/routers/analyze.py
@@ -22,7 +22,7 @@ async def analyze(
     """
     1) Descarga el audio desde la URL recibida (Telegram).
     2) Sube a S3 con clave {ENV}/{uuid}.{ext}.
-    3) Publica en Kafka (topic processing) {user_id, audio_id, request_message, scenario, duration_minutes}.
+    3) Publica en Kafka (topic processing) {user_id, audio_id, request_message, scenario[, duration_minutes]}.
     4) Devuelve ACK con audio_key.
     """
     # Find or create user
@@ -61,13 +61,16 @@ async def analyze(
 
     # 3) Enviar a Kafka
     try:
+        if req.scenario == "adaptation" and req.duration_minutes is None:
+            raise HTTPException(status_code=400, detail="duration_minutes required")
         payload = {
             "user_id": req.user_id,
             "audio_id": key,
             "request_message": "",
             "scenario": req.scenario,
-            "duration_minutes": req.duration_minutes,
         }
+        if req.duration_minutes is not None:
+            payload["duration_minutes"] = req.duration_minutes
         kafka_producer.enqueue_for_processing(payload)
         kafka_producer.flush()
         crud.create_pitch(

--- a/app/schemas/analyze.py
+++ b/app/schemas/analyze.py
@@ -2,14 +2,14 @@
 from pydantic import BaseModel, AnyHttpUrl, Field
 from typing import Literal, Optional
 
-Scenario = Literal["investor", "client", "academic"]
+Scenario = Literal["recommendation", "evaluation", "adaptation"]
 DurationMinutes = Literal[1, 3, 5]
 
 
 class AnalyzeRequest(BaseModel):
     user_id: str
-    scenario: Scenario = "investor"
-    duration_minutes: DurationMinutes = 1
+    scenario: Scenario = "recommendation"
+    duration_minutes: Optional[DurationMinutes] = None
     audio_url: AnyHttpUrl
     media_duration_sec: Optional[int] = Field(default=None, ge=0)
 

--- a/bot/run.py
+++ b/bot/run.py
@@ -30,11 +30,11 @@ dp = Dispatcher()
 
 # ---------- UI helpers ----------
 SCENARIO_LABELS = {
-    "investor": "Инвестор",
-    "client": "Клиент",
-    "academic": "Академический",
+    "recommendation": "Рекомендации",
+    "evaluation": "Оценка",
+    "adaptation": "Адаптация",
 }
-SCENARIO_ORDER = ["investor", "client", "academic"]
+SCENARIO_ORDER = ["recommendation", "evaluation", "adaptation"]
 DURATION_ORDER = [1, 3, 5]  # минуты
 
 
@@ -45,7 +45,7 @@ def tg_file_url(token: str, file_path: str) -> str:
 @dataclass
 class UserSession:
     audio_url: Optional[str] = None
-    scenario: str = "investor"
+    scenario: str = "recommendation"
     duration_minutes: int = 1
     menu_message_id: Optional[int] = None
     menu_chat_id: Optional[int] = None
@@ -57,48 +57,45 @@ sessions: Dict[int, UserSession] = {}
 
 
 def build_menu(session: UserSession) -> "InlineKeyboardMarkup":
-    """
-    Teclado con selección de escenario + duración + acciones.
-    Marca la opción elegida con '✅'.
-    """
+    """Construye клавиатуру с выбором сценария и, при необходимости, длительности."""
     kb = InlineKeyboardBuilder()
 
     # Escenarios (fila 1)
-    row = []
     for sc in SCENARIO_ORDER:
         label = SCENARIO_LABELS[sc]
-        if sc == session.scenario:
-            text = f"✅ {label}"
-        else:
-            text = label
+        text = f"✅ {label}" if sc == session.scenario else label
         kb.button(text=text, callback_data=f"sc:{sc}")
-    kb.adjust(3)
 
-    # Duraciones (fila 2)
-    for dur in DURATION_ORDER:
-        if dur == session.duration_minutes:
-            text = f"✅ {dur} мин"
-        else:
-            text = f"{dur} мин"
-        kb.button(text=text, callback_data=f"du:{dur}")
-    kb.adjust(3, 3)
+    # Duraciones (fila 2) — только для сценария адаптации
+    if session.scenario == "adaptation":
+        for dur in DURATION_ORDER:
+            text = f"✅ {dur} мин" if dur == session.duration_minutes else f"{dur} мин"
+            kb.button(text=text, callback_data=f"du:{dur}")
 
-    # Acciones (fila 3)
+    # Acciones (últняя fila)
     kb.button(text="🚀 Отправить на анализ", callback_data="go:analyze")
     kb.button(text="🔄 Сбросить", callback_data="go:reset")
-    kb.adjust(3, 3, 2)
+
+    if session.scenario == "adaptation":
+        kb.adjust(3, 3, 2)
+    else:
+        kb.adjust(3, 2)
 
     return kb.as_markup()
 
 
 def menu_text(session: UserSession) -> str:
-    return (
+    text = (
         "🎙️ *Анализ питча*\n\n"
-        "Выберите *сценарий* и *длительность* обзора.\n\n"
+        "Выберите *сценарий*. Для адаптации можно указать длительность.\n\n"
         f"• Сценарий: *{SCENARIO_LABELS.get(session.scenario, '—')}*\n"
-        f"• Длительность: *{session.duration_minutes} мин*\n\n"
-        "Когда всё готово — нажмите _«Отправить на анализ»_."
     )
+    if session.scenario == "adaptation":
+        text += f"• Длительность: *{session.duration_minutes} мин*\n\n"
+    else:
+        text += "\n"
+    text += "Когда всё готово — нажмите _«Отправить на анализ»_."
+    return text
 
 
 # ---------- Handlers ----------
@@ -108,8 +105,8 @@ async def cmd_start(msg: Message):
         "👋 Добро пожаловать в *PitchBoost Bot*!\n\n"
         "Отправьте мне голосовое сообщение 🎙️ со своим питчем.\n\n"
         "После этого вы сможете выбрать:\n"
-        "• *Сценарий*: 💼 Инвестор | 🤝 Клиент | 🎓 Академический\n"
-        "• *Длительность*: ⏱️ 1, 3 или 5 минут\n\n"
+        "• *Сценарий*: 💡 Рекомендации | 📝 Оценка | 🔧 Адаптация\n"
+        "• Для адаптации: длительность 1, 3 или 5 минут\n\n"
         "Я дам вам обратную связь 💡: сильные стороны, зоны роста и улучшенную версию питча."
     )
     await msg.answer(text, parse_mode="Markdown")
@@ -120,7 +117,7 @@ async def handle_voice(msg: Message):
     """
     1) Получаем file_path от Telegram → собираем прямой file URL.
     2) Запоминаем URL в сессии пользователя.
-    3) Показываем меню выбора сценария и длительности.
+    3) Показываем меню выбора сценария и длительности (для адаптации).
     """
     user_id = msg.from_user.id
     duration = msg.voice.duration
@@ -148,7 +145,7 @@ async def handle_voice(msg: Message):
 
     text = (
         "💡 *Шаг 1/2*. Я получил голосовое сообщение.\n"
-        "Теперь выберите *сценарий* и *длительность* для анализа.\n"
+        "Теперь выберите *сценарий*. Для адаптации можно указать длительность.\n"
         "После этого я отправлю запрос и пришлю итог, как только он будет готов."
     )
     await msg.answer(text, parse_mode="Markdown")
@@ -189,7 +186,7 @@ async def handle_audio(msg: Message):
 
     text = (
         "💡 *Шаг 1/2*. Я получил аудиофайл.\n"
-        "Теперь выберите *сценарий* и *длительность* для анализа.\n"
+        "Теперь выберите *сценарий*. Для адаптации можно указать длительность.\n"
         "После этого я отправлю запрос и пришлю итог, как только он будет готов."
     )
     await msg.answer(text, parse_mode="Markdown")
@@ -253,7 +250,7 @@ async def reset_session(call: CallbackQuery):
 async def run_analysis(call: CallbackQuery):
     """
     Когда пользователь нажимает «Отправить на анализ», шлём POST в API:
-    { user_id, scenario, duration_minutes, audio_url }.
+    { user_id, scenario, audio_url, [duration_minutes] }.
     Дальше результат придёт через Kafka → бот отправит ответ в чат.
     """
     user_id = call.from_user.id
@@ -265,10 +262,11 @@ async def run_analysis(call: CallbackQuery):
     payload = {
         "user_id": str(user_id),
         "scenario": session.scenario,
-        "duration_minutes": session.duration_minutes,
         "audio_url": session.audio_url,
         "media_duration_sec": session.media_duration_sec,
     }
+    if session.scenario == "adaptation":
+        payload["duration_minutes"] = session.duration_minutes
 
     try:
         await call.answer("Отправляю…")
@@ -287,12 +285,13 @@ async def run_analysis(call: CallbackQuery):
         return
 
     # UX: подтвердить и напомнить что ответ придёт позже (через Kafka)
-    await call.message.answer(
+    confirm = (
         "✅ Запрос принят! Я пришлю результат, как только он будет готов.\n\n"
         f"• Сценарий: *{SCENARIO_LABELS.get(session.scenario, '—')}*\n"
-        f"• Длительность: *{session.duration_minutes} мин*",
-        parse_mode="Markdown",
     )
+    if session.scenario == "adaptation":
+        confirm += f"• Длительность: *{session.duration_minutes} мин*"
+    await call.message.answer(confirm, parse_mode="Markdown")
 
 
 # ---- payments ----

--- a/tests/test_credits_gate.py
+++ b/tests/test_credits_gate.py
@@ -20,8 +20,7 @@ def analyze(client):
         "/v1/analyze",
         json={
             "user_id": "u1",
-            "scenario": "investor",
-            "duration_minutes": 1,
+            "scenario": "recommendation",
             "audio_url": "http://example.com/a.ogg",
             "media_duration_sec": 10,
         },

--- a/tests/test_duration_gate.py
+++ b/tests/test_duration_gate.py
@@ -21,8 +21,7 @@ def test_duration_gate(client, monkeypatch):
         "/v1/analyze",
         json={
             "user_id": "u1",
-            "scenario": "investor",
-            "duration_minutes": 1,
+            "scenario": "recommendation",
             "audio_url": "http://example.com/a.ogg",
             "media_duration_sec": settings.AUDIO_MAX_SECONDS + 1,
         },
@@ -33,8 +32,7 @@ def test_duration_gate(client, monkeypatch):
         "/v1/analyze",
         json={
             "user_id": "u1",
-            "scenario": "investor",
-            "duration_minutes": 1,
+            "scenario": "recommendation",
             "audio_url": "http://example.com/a.ogg",
             "media_duration_sec": settings.AUDIO_MAX_SECONDS - 1,
         },

--- a/tests/test_kafka_message_shape.py
+++ b/tests/test_kafka_message_shape.py
@@ -6,7 +6,7 @@ async def fake_upload_audio_from_url(url: str, user_id: str):
     return {"bucket": "b", "key": "k123", "size": "1", "content_type": "audio/ogg"}
 
 
-def test_kafka_payload_shape(client, monkeypatch):
+def test_kafka_payload_shape_with_duration(client, monkeypatch):
     monkeypatch.setattr(
         storage.storage, "upload_audio_from_url", fake_upload_audio_from_url
     )
@@ -22,7 +22,7 @@ def test_kafka_payload_shape(client, monkeypatch):
         "/v1/analyze",
         json={
             "user_id": "u1",
-            "scenario": "investor",
+            "scenario": "adaptation",
             "duration_minutes": 1,
             "audio_url": "http://example.com/a.ogg",
             "media_duration_sec": 10,
@@ -36,4 +36,35 @@ def test_kafka_payload_shape(client, monkeypatch):
         "request_message",
         "scenario",
         "duration_minutes",
+    }
+
+
+def test_kafka_payload_shape_without_duration(client, monkeypatch):
+    monkeypatch.setattr(
+        storage.storage, "upload_audio_from_url", fake_upload_audio_from_url
+    )
+    captured = {}
+
+    def fake_enqueue(payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(kafka_producer, "enqueue_for_processing", fake_enqueue)
+    monkeypatch.setattr(kafka_producer, "flush", lambda: None)
+
+    resp = client.post(
+        "/v1/analyze",
+        json={
+            "user_id": "u1",
+            "scenario": "recommendation",
+            "audio_url": "http://example.com/a.ogg",
+            "media_duration_sec": 10,
+        },
+    )
+    assert resp.status_code == 202
+    payload = captured["payload"]
+    assert set(payload.keys()) == {
+        "user_id",
+        "audio_id",
+        "request_message",
+        "scenario",
     }


### PR DESCRIPTION
## Summary
- show duration buttons only when "Адаптация" scenario is chosen
- send duration_minutes to API only for adaptation and document optional field
- loosen API schema and DB to accept missing duration

## Testing
- `flake8 bot/run.py app/schemas/analyze.py tests/test_*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9468dd48322a3b2c3fc63ca6ac8